### PR TITLE
Ge08

### DIFF
--- a/ge06_team01/__init__.py
+++ b/ge06_team01/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ge06_team01/__manifest__.py
+++ b/ge06_team01/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "GE06 Team 01",
+    "summary": "Compute serial number from a VIN",
+    "description": """
+    This module create a serial number using the same format as a VIN, 
+    the format is only available for products wich 'detailed_type' = 'motorcycle'
+        Developer: [DIZR] Diego Zúñiga Rodríguez
+        Task ID: GE6
+        Task URL: https://www.odoo.com/web#id=3426312&cids=17&menu_id=4720&action=4043&model=project.task&view_type=form
+    """,
+    "version": "0.1",
+    "category": "Kauil/Training",
+    "license": "OPL-1",
+    "depends": ["stock"],
+    "data": [
+        'data/serial_number_data.xml',
+    ],
+    "author": "Odoo Inc",
+    "website": "www.odoo.com",
+    "application": True,
+}

--- a/ge06_team01/data/serial_number_data.xml
+++ b/ge06_team01/data/serial_number_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="sequence_serial" model="ir.sequence">
+            <field name="name">Serial Number</field>
+            <field name="code">serial.number</field>
+            <field name="prefix"></field>
+            <field name="padding">5</field>
+            <field name="number_next">1</field>
+            <field name="number_increment">1</field>
+        </record>
+    </data>
+</odoo>

--- a/ge06_team01/models/__init__.py
+++ b/ge06_team01/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock

--- a/ge06_team01/models/stock.py
+++ b/ge06_team01/models/stock.py
@@ -1,0 +1,19 @@
+from odoo import api, models
+
+
+class StockLot(models.Model):
+    _inherit = 'stock.lot'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            product = self.env['product.product'].search([("id", "=", vals['product_id'])])
+
+            if product.detailed_type == "motorcycle":
+                product_make = product.make[:2].upper()
+                product_model = product.model[:2].upper()
+                product_year = str(product.year)[-2:]
+                product_battery = product.battery_capacity[:2].upper()
+                vals[
+                    'name'] = f"{product_make}{product_model}{product_year}{product_battery}{self.env['ir.sequence'].next_by_code('serial.number')}"
+        return super().create(vals_list)

--- a/ge07_team01/__init__.py
+++ b/ge07_team01/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ge07_team01/__manifest__.py
+++ b/ge07_team01/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "GE07 Team 01",
+    "summary": "Seventh group task.",
+    "description": """
+Automates the creation of a motorcycle registry when the delivery is validated. Adds a 'Sale Order' buttton to the
+registry's form view, to trace the sale order of it. Also adds a Lot ID field to the registry's list view and a
+Registry ID to the stock.lot's list view.
+Developers: [DIZR] Diego Zúñiga Rodríguez, [RIAA] Ricardo Alonso, [JIVP] Jordan Vega, [COAL] Corinne Angélica
+Task ID: GE7
+Task URL: https://www.odoo.com/web#id=3427405&cids=17&menu_id=4720&action=4665&active_id=3427418&model=project.task&view_type=form
+    """,
+    "version": "1.0.0",
+    "category": "Custom Developoment",
+    "license": "OPL-1",
+    "depends": ["ge06_team01", "motorcycle_registry", "sale", "stock"],
+    "data": [
+        "views/stock_lot_inherit.xml",
+        'views/motorcycle_registry_inherit.xml'
+    ],
+    "author": "Odoo Inc",
+    "website": "www.odoo.com",
+    "application": True
+}

--- a/ge07_team01/models/__init__.py
+++ b/ge07_team01/models/__init__.py
@@ -1,0 +1,3 @@
+from . import motorcycle_registry
+from . import stock_lot
+from . import stock_picking

--- a/ge07_team01/models/motorcycle_registry.py
+++ b/ge07_team01/models/motorcycle_registry.py
@@ -1,0 +1,32 @@
+from odoo import api, models, fields
+from odoo.exceptions import ValidationError
+
+
+class MotorcycleRegistry(models.Model):
+    _inherit = "motorcycle.registry"
+
+    lot_ids = fields.One2many("stock.lot", "registry_id", string="Lot IDs")
+    lot_id = fields.Many2one("stock.lot", string="Lot ID", compute="_compute_lot_id", store=True)
+    sale_order_id = fields.Many2one("sale.order")
+
+    vin = fields.Char(string="VIN", related="lot_id.name", required=False)
+    owner_id = fields.Many2one("res.partner", string="Owner", related="sale_order_id.partner_id")
+    registry_date = fields.Date(string='Registration Date', default=fields.Date.today())
+
+    @api.constrains("lot_ids")
+    def _check_lot_ids(self):
+        for registry in self:
+            if len(registry.lot_ids) > 1:
+                raise ValidationError("lot_ids cannot have more than one lot.")
+
+    @api.depends("lot_ids")
+    def _compute_lot_id(self):
+        self.lot_id = False
+        for registry in self.filtered(lambda r: r.lot_ids is not False and len(r.lot_ids) > 0):
+            registry.lot_id = registry.lot_ids[0]
+
+    def action_view_sale_order(self):
+        action = self.env['ir.actions.act_window']._for_xml_id('sale.action_orders')
+        action["views"] = [(False, 'form')]
+        action["res_id"] = self.sale_order_id.id
+        return action

--- a/ge07_team01/models/stock_lot.py
+++ b/ge07_team01/models/stock_lot.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class StockLot(models.Model):
+    _inherit = "stock.lot"
+
+    registry_id = fields.Many2one("motorcycle.registry")

--- a/ge07_team01/models/stock_picking.py
+++ b/ge07_team01/models/stock_picking.py
@@ -1,0 +1,18 @@
+from odoo import models
+
+
+class Picking(models.Model):
+    _inherit = "stock.picking"
+
+    def _action_done(self):
+        res = super()._action_done()
+        vals_list = []
+        for line in self.move_line_ids.filtered(
+                lambda l: l.product_id.detailed_type == "motorcycle" and l.state == "done"):
+            vals = {
+                "sale_order_id": self.sale_id.id,
+                "lot_ids": [line.lot_id.id]
+            }
+            vals_list.append(vals)
+        self.env['motorcycle.registry'].create(vals_list)
+        return res

--- a/ge07_team01/views/motorcycle_registry_inherit.xml
+++ b/ge07_team01/views/motorcycle_registry_inherit.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="motorcycle_registry_view_form_inherit_motorcycle_registry" model="ir.ui.view">
+        <field name="name">motorcycle.registry.view.form.inherit.motorcycle.registry</field>
+        <field name="model">motorcycle.registry</field>
+        <field name="inherit_id" ref="motorcycle_registry.motorcycle_registry_view_form" />
+        <field name="arch" type="xml">
+            <field name="picture" position="before">
+                <field name="sale_order_id" invisible="1" />
+                <div class="oe_button_box" name="button_box">
+                    <button class="oe_stat_button"
+                        type="object"
+                        name="action_view_sale_order"
+                        string="Sale Order"
+                        title="Sale Order"
+                        icon="fa-usd"
+                        attrs="{'invisible': [('sale_order_id', '=', False)]}">
+                    </button>
+                </div>
+            </field>
+        </field>
+    </record>
+
+    <record id="motorcycle_registry_view_list_inherit_motorcycle_registry" model="ir.ui.view">
+        <field name="name">motorcycle.registry.view.list.inherit.motorcycle.registry</field>
+        <field name="model">motorcycle.registry</field>
+        <field name="inherit_id" ref="motorcycle_registry.motorcycle_registry_view_list" />
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field name="lot_id" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/ge07_team01/views/stock_lot_inherit.xml
+++ b/ge07_team01/views/stock_lot_inherit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_production_lot_tree_inherit_motorcycle_registry" model="ir.ui.view">
+        <field name="name">view.production.lot.tree.inherit.motorcycle.registry</field>
+        <field name="model">stock.lot</field>
+        <field name="inherit_id" ref="stock.view_production_lot_tree" />
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field name="registry_id" />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/ge08_team01/__init__.py
+++ b/ge08_team01/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/ge08_team01/__manifest__.py
+++ b/ge08_team01/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "GE08 Team 01",
+    "summary": "Eighth group task.",
+    "description": """
+Handle portal views (tree and form), allows to a costumer edit its registries and make it public or private.
+Search for public registries based on: owner's name, country or state; motorcycle's make or model.
+Search function to computed fields implemented.
+Developers: [RIAA] Ricardo Alonso, [DIZR] Diego Zúñiga
+Task ID: GE8
+Task URL: https://www.odoo.com/web#id=3427407&cids=17&menu_id=4720&action=4665&active_id=3427418&model=project.task&view_type=form
+    """,
+    "version": "0.1",
+    "category": "Custom Developoment",
+    "license": "OPL-1",
+    "data": [
+        "views/motorcycle_registry_portal_templates.xml",
+        "views/motorcycle_registry_inherit.xml"
+    ],
+    "depends": ["ge07_team01", "motorcycle_registry", "sale"],
+    "author": "Odoo Inc",
+    "website": "www.odoo.com",
+    "application": True
+}

--- a/ge08_team01/controllers/__init__.py
+++ b/ge08_team01/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/ge08_team01/controllers/portal.py
+++ b/ge08_team01/controllers/portal.py
@@ -1,0 +1,125 @@
+from odoo import http, _
+from odoo.addons.portal.controllers import portal
+from odoo.exceptions import AccessError, MissingError
+from odoo.http import request
+
+from odoo.addons.portal.controllers.portal import pager as portal_pager
+from odoo.osv.expression import OR
+
+import re
+
+
+class PortalMotorcycleRegistry(portal.CustomerPortal):
+
+    def _prepare_home_portal_values(self, counters):
+        values = super()._prepare_home_portal_values(counters)
+
+        MotorcycleRegistry = request.env["motorcycle.registry"]
+        if "registry_count" in counters:
+            values["registry_count"] = MotorcycleRegistry.search_count(
+                [("owner_id", "=", request.env.user.partner_id.id)]) if MotorcycleRegistry.check_access_rights(
+                "read", raise_exception=False) else 0
+        return values
+
+    def _prepare_motorcycle_registry_portal_rendering_values(
+            self, page=1, sortby=None, search_in="all", search=None, **kwargs):
+        MotorcycleRegistry = request.env["motorcycle.registry"]
+
+        if not sortby:
+            sortby = "registry_number"
+
+        domain = ["|", ("owner_id", "=", request.env.user.partner_id.id), ("is_public", "=", "True")]
+        url = "/my/registries"
+        values = self._prepare_portal_layout_values()
+
+        searchbar_sortings = self._get_registry_searchbar_sortings()
+        searchbar_inputs = self._get_registry_searchbar_inputs()
+        sort_order = searchbar_sortings[sortby]["order"]
+
+        pager_values = portal_pager(
+            url=url,
+            total=MotorcycleRegistry.search_count(domain),
+            page=page,
+            step=self._items_per_page,
+            url_args={"sortby": sortby, "search_in": search_in, "search": search}
+        )
+
+        if search and search_in:
+            domain += self._get_search_domain(search_in, search)
+
+        registries = MotorcycleRegistry.search(
+            domain, order=sort_order, limit=self._items_per_page, offset=pager_values['offset'])
+
+        values.update({
+            "registries": registries.sudo(),
+            "page_name": "motorcycle_registry",
+            "pager": pager_values,
+            "default_url": url,
+            "searchbar_inputs": searchbar_inputs,
+            "searchbar_sortings": searchbar_sortings,
+            "search": search,
+            "search_in": search_in,
+            "sortby": sortby,
+        })
+
+        return values
+
+    def _get_registry_searchbar_inputs(self):
+        return {
+            'all': {'input': 'all', 'label': _('Search All')},
+            'name': {'input': 'name', 'label': _('Search by Name')},
+            'country': {'input': 'country', 'label': _('Search by Country')},
+            'state': {'input': 'state', 'label': _('Search by State')},
+            'make': {'input': 'make', 'label': _('Search by Make')},
+            'model': {'input': 'model', 'label': _('Search by Model')},
+        }
+
+    def _get_registry_searchbar_sortings(self):
+        return {
+            'registry_number': {'label': _('ID'), 'order': 'registry_number desc'},
+            'name': {'label': _('Owner name'), 'order': 'owner_id desc'},
+            'model': {'label': _('Model'), 'order': 'model asc'},
+            'make': {'label': _('Brand'), 'order': 'make'},
+            'mileage': {'label': _('Road Experience'), 'order': 'current_mileage desc'},
+            'lp': {'label': _('License Plate'), 'order': 'license_plate asc'},
+        }
+
+    def _get_search_domain(self, search_in, search):
+        search_domain = []
+        if search_in in ('name', 'all'):
+            search_domain = OR([search_domain, [('owner_id', 'ilike', search)]])
+        if search_in in ('country', 'all'):
+            search_domain = OR([search_domain, [('owner_id.country_id', 'ilike', search)]])
+        if search_in in ('state', 'all'):
+            search_domain = OR([search_domain, [('owner_id.state_id', 'ilike', search)]])
+        if search_in in ('make', 'all'):
+            search_domain = OR([search_domain, [('make', '=ilike', search)]])
+        if search_in in ('model', 'all'):
+            search_domain = OR([search_domain, [('model', '=ilike', search)]])
+        return search_domain
+
+    @http.route("/my/registries", type="http", auth="user", website=True)
+    def portal_my_registries(self, **kwargs):
+        values = self._prepare_motorcycle_registry_portal_rendering_values(**kwargs)
+        return http.request.render("ge08_team01.portal_my_motorcycle_registries_list", values)
+
+    @http.route(["/my/registries/<int:registry_id>"], type="http", auth="public", website=True)
+    def portal_registry_page(self, registry_id, access_token=None):
+        try:
+            registry_sudo = self._document_check_access("motorcycle.registry", registry_id, access_token=access_token)
+        except (AccessError, MissingError):
+            return request.redirect("/my")
+
+        backend_url = f"/web#model={registry_sudo._name}"\
+                      f"&id={registry_sudo.id}"\
+                      f"&action={registry_sudo._get_portal_return_action().id}"\
+                      f"&view_type=form"
+
+        values = {
+            "registry": registry_sudo,
+            "report_type": "html",
+            "backend_url": backend_url
+        }
+
+        values = self._get_page_view_values(registry_sudo, access_token, values, "my_registrations_history", False)
+        return request.render("ge08_team01.motorcycle_registry_portal_template", values)

--- a/ge08_team01/models/__init__.py
+++ b/ge08_team01/models/__init__.py
@@ -1,0 +1,1 @@
+from . import motorcycle_registry

--- a/ge08_team01/models/motorcycle_registry.py
+++ b/ge08_team01/models/motorcycle_registry.py
@@ -1,0 +1,47 @@
+# Inherit the motorcycle.registry model and add the portal.mixin
+from odoo import fields, models
+
+
+class MotorcycleRegistry(models.Model):
+    _name = "motorcycle.registry"
+    _inherit = ["motorcycle.registry", "portal.mixin"]
+
+    is_public = fields.Boolean("Public", default=False)
+
+    model = fields.Char(search = '_search_model')
+    make = fields.Char(search = '_search_make')
+
+    def _get_portal_return_action(self):
+        self.ensure_one()
+        return self.env.ref("motorcycle_registry.registry_list_action")
+
+    # portal.mixin override
+    def _compute_access_url(self):
+        super()._compute_access_url()
+        for registry in self:
+            registry.access_url = f"/my/registries/{registry.id}"
+
+    def _set_is_public(self):
+        self.ensure_one()
+        self.is_public = not self.is_public
+
+    def _search_model(self, operator, value):
+        domain = []
+        if len(value) == 1:
+            domain = ['|', ('vin', operator, f'__{value}_%'), ('vin', operator, f'___{value}%')]
+        elif len(value) == 2:
+            domain = [('vin', operator, f'__{value}%')]
+            
+        print(domain)
+        return domain
+
+    def _search_make(self, operator, value):
+        domain = []
+        if len(value) == 1:
+            domain = ['|', ('vin', operator, f'_{value}%'), ('vin', operator, f'{value}_%')]
+        elif len(value) == 2:
+            domain = [('vin', operator, f'{value}%')]
+            
+        print(domain)
+        return domain
+    

--- a/ge08_team01/views/motorcycle_registry_inherit.xml
+++ b/ge08_team01/views/motorcycle_registry_inherit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="motorcycle_registry_view_form_inherit_motorcycle_registry" model="ir.ui.view">
+        <field name="name">motorcycle.registry.view.form.inherit.motorcycle.registry</field>
+        <field name="model">motorcycle.registry</field>
+        <field name="inherit_id" ref="motorcycle_registry.motorcycle_registry_view_form" />
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Portal Settings" name="portal_settings">
+                    <group>
+                        <field name="is_public" />
+                    </group>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>

--- a/ge08_team01/views/motorcycle_registry_portal_templates.xml
+++ b/ge08_team01/views/motorcycle_registry_portal_templates.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <template id="portal_my_home_menu_motorcycle_registry"
+            name="Portal layout : motorcycle registry menu entries"
+            inherit_id="portal.portal_breadcrumbs" priority="25">
+            <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">
+                <li t-if="page_name == 'motorcycle_registry' or registry"
+                    t-attf-class="breadcrumb-item #{'active ' if not registry else ''}">
+                    <a t-if="registry" t-attf-href="/my/registries?{{ keep_query() }}">Registries</a>
+                    <t t-else="">Registries</t>
+                </li>
+                <li t-if="registry" class="breadcrumb-item active">
+                    <span />
+                    <t t-out="registry.registry_number" />
+                </li>
+            </xpath>
+        </template>
+
+        <template id="portal_my_home_motorcycle_registry" name="Show Motorcycle Registries"
+            customize_show="True" inherit_id="portal.portal_my_home" priority="20">
+            <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
+                <t t-call="portal.portal_docs_entry">
+                    <t t-set="title">Motorcycle Registries</t>
+                    <t t-set="url" t-value="'/my/registries'" />
+                    <t t-set="placeholder_count" t-value="'registry_count'" />
+                </t>
+            </xpath>
+        </template>
+
+        <template id="portal_my_motorcycle_registries_list" name="My Motorcycle Registries">
+            <t t-call="portal.portal_layout">
+                <t t-set="breadcrumbs_searchbar" t-value="True" />
+
+                <t t-call="portal.portal_searchbar">
+                    <t t-set="title">Motorcycle Registries</t>
+                </t>
+                <t t-call="portal.portal_table">
+                    <thead>
+                        <tr class="active">
+                            <th>Registry #</th>
+                            <th>VIN</th>
+                            <th>Make</th>
+                            <th>Model</th>
+                            <th>License Plate Number</th>
+                            <th>Owner</th>
+                            <th>Lot ID</th>
+                        </tr>
+                    </thead>
+                    <t t-foreach="registries" t-as="registry">
+                        <tr>
+                            <td>
+                                <a t-att-href="registry.get_portal_url()">
+                                    <t t-out="registry.registry_number" />
+                                </a>
+                            </td>
+                            <td>
+                                <span t-field="registry.vin" />
+                            </td>
+                            <td>
+                                <span t-field="registry.make" />
+                            </td>
+                            <td>
+                                <span t-field="registry.model" />
+                            </td>
+                            <td>
+                                <span t-field="registry.license_plate" />
+                            </td>
+                            <td>
+                                <span t-field="registry.owner_id" />
+                            </td>
+                            <td>
+                                <span t-field="registry.lot_id" />
+                            </td>
+                        </tr>
+                    </t>
+                </t>
+            </t>
+        </template>
+
+        <template id="motorcycle_registry_portal_template"
+            name="Motorcycle Registry Portal Template" inherit_id="portal.portal_sidebar"
+            primary="True">
+            <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
+                <t t-set="custom_html">This is the portal view of your Motorcycle Registry.</t>
+                <t t-if="registry.owner_id == env.user.partner_id"
+                    t-set="o_portal_fullwidth_alert"
+                    groups="motorcycle_registry.group_registry_user">
+                    <t t-call="portal.portal_back_in_edit_mode" />
+                </t>
+
+                <div class="row mt16 o_portal_sidebar">
+                    <!-- Sidebar -->
+                    <t t-call="portal.portal_record_sidebar">
+                        <t t-set="classes" t-value="'col-lg-auto d-print-none'" />
+
+                        <t t-set="title">
+                            <h2 class="mb-0">
+                                <b t-field="registry.make" data-id="vin" />
+                                <b t-field="registry.model" data-id="model" />
+                            </h2>
+                        </t>
+                        <t t-set="entries">
+                            <ul
+                                class="list-group list-group-flush flex-wrap flex-row flex-lg-column">
+                                <li t-if="registry.owner_id" class="list-group-item flex-grow-1">
+                                    <div class="small mb-1">
+                                        <strong class="text-muted">
+                                            <t>
+                                                Owner
+                                            </t>
+                                        </strong>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col flex-grow-0 pe-2">
+                                            <img class="rounded-circle mt-1 o_portal_contact_img"
+                                                t-att-src="image_data_uri(registry.owner_id.avatar_1024)"
+                                                alt="Contact" />
+                                        </div>
+                                        <div class="col ps-0">
+                                            <span t-field="registry.owner_id"
+                                                t-options='{"widget": "contact", "fields": ["name", "phone", "email"], "no_marker": True}' />
+                                        </div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </t>
+                    </t>
+
+                    <div id="registry_content" class="col-12 col-lg justify-content-end">
+                        <!-- main content -->
+                        <div t-attf-class="card #{'pb-5' if report_type == 'html' else ''}"
+                            id="portal_registry_content">
+                            <div t-call="ge08_team01.motorcycle_registry_portal_content" />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </template>
+
+        <template id="motorcycle_registry_portal_content" name="Motorcycle Registry Portal Content">
+            <!-- Intro -->
+            <div id="introduction"
+                t-attf-class="pb-2 pt-3 #{'card-header bg-white' if report_type == 'html' else ''}">
+                <h2 class="my-0">
+                    <em t-out="registry.registry_number" />
+                </h2>
+            </div>
+
+            <div t-attf-class="#{'card-body' if report_type == 'html' else ''}">
+                <!-- Informations -->
+                <div class="row">
+                    <div t-if="registry.picture" class="col-lg-6 col-12" id="reg_picture">
+                        <div class="o_field_widget o_field_image oe_avatar">
+                            <div style="height: 256px; overflow:hidden;">
+                                <div t-field="registry.picture"
+                                    t-options="{'widget': 'image', 'qweb_img_responsive': True, 'class': 'img img-fluid w-100'}" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-6 col-12" id="informations">
+                        <div class="row" id="reg_date">
+                            <div class="mb-3 col-6">
+                                <strong>Registration Date:</strong>
+                                <span t-field="registry.registry_date"
+                                    t-options='{"widget": "date"}' />
+                            </div>
+                        </div>
+                        <div class="row" id="reg_vin">
+                            <div class="mb-3 col-6">
+                                <strong>VIN:</strong>
+                                <span t-field="registry.vin" />
+                            </div>
+                        </div>
+                        <div class="row" id="reg_make">
+                            <div class="mb-3 col-6">
+                                <strong>Make:</strong>
+                                <span t-field="registry.make" />
+                            </div>
+                        </div>
+                        <div class="row" id="reg_model">
+                            <div class="mb-3 col-6">
+                                <strong>Model:</strong>
+                                <span t-field="registry.model" />
+                            </div>
+                        </div>
+                        <div class="row" id="reg_mileage">
+                            <div class="mb-3 col-6">
+                                <strong>Current mileage:</strong>
+                                <span t-field="registry.current_mileage" />
+                            </div>
+                        </div>
+                        <div class="row" id="reg_plate">
+                            <div class="mb-3 col-6">
+                                <strong>License Plate Number:</strong>
+                                <span t-field="registry.license_plate" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
Kawiil wanted their customers to view their registries information on the customer portal. They as well wanted their customers to be able to edit and to opt in to make their records public and to see others records.

This module adds 'Motorcycle Registries' to the 'My Account' page. This controller redirects to the registries list view. All of the user's registries as well as public ones (the ones with the field 'is_public' set to True) are displayed here. Users may filter registries by state, country or owner. Each registry in the list has a link button in the 'registry_number', which redirects the user to the registry's form view.

A 'Back to edit mode' was added in the form view, which redirects the user to the registry's backend view, to let them edit their own registries.

Handle search by make and model

[IMP] Removed unnecesary comment